### PR TITLE
Stops using UserDefaults for queue on tvOS and uses NSCachesDirectory

### DIFF
--- a/Analytics/Classes/Internal/SEGFileStorage.h
+++ b/Analytics/Classes/Internal/SEGFileStorage.h
@@ -13,11 +13,11 @@
 
 @property (nonatomic, strong, nullable) id<SEGCrypto> crypto;
 
-- (instancetype _Nonnull)init;
 - (instancetype _Nonnull)initWithFolder:(NSURL *_Nonnull)folderURL crypto:(id<SEGCrypto> _Nullable)crypto;
 
 - (NSURL *_Nonnull)urlForKey:(NSString *_Nonnull)key;
 
-+ (NSURL *_Nullable)fileStorageURL;
++ (NSURL *_Nullable)applicationSupportDirectoryURL;
++ (NSURL *_Nullable)cachesDirectoryURL;
 
 @end

--- a/Analytics/Classes/Internal/SEGFileStorage.h
+++ b/Analytics/Classes/Internal/SEGFileStorage.h
@@ -18,6 +18,6 @@
 
 - (NSURL *_Nonnull)urlForKey:(NSString *_Nonnull)key;
 
-+ (NSURL *_Nullable)applicationSupportDirectoryURL;
++ (NSURL *_Nullable)fileStorageURL;
 
 @end

--- a/Analytics/Classes/Internal/SEGFileStorage.m
+++ b/Analytics/Classes/Internal/SEGFileStorage.m
@@ -19,11 +19,6 @@
 
 @implementation SEGFileStorage
 
-- (instancetype)init
-{
-    return [self initWithFolder:[SEGFileStorage fileStorageURL] crypto:nil];
-}
-
 - (instancetype)initWithFolder:(NSURL *)folderURL crypto:(id<SEGCrypto>)crypto
 {
     if (self = [super init]) {
@@ -121,14 +116,17 @@
     [self setJSON:data forKey:key];
 }
 
-+ (NSURL *)fileStorageURL
+
++ (NSURL *)applicationSupportDirectoryURL
 {
-    #if TARGET_OS_TV
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    #else
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-    #endif
-    
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+    NSString *storagePath = [paths firstObject];
+    return [NSURL fileURLWithPath:storagePath];
+}
+
++ (NSURL *)cachesDirectoryURL
+{
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     NSString *storagePath = [paths firstObject];
     return [NSURL fileURLWithPath:storagePath];
 }

--- a/Analytics/Classes/Internal/SEGFileStorage.m
+++ b/Analytics/Classes/Internal/SEGFileStorage.m
@@ -21,7 +21,7 @@
 
 - (instancetype)init
 {
-    return [self initWithFolder:[SEGFileStorage applicationSupportDirectoryURL] crypto:nil];
+    return [self initWithFolder:[SEGFileStorage fileStorageURL] crypto:nil];
 }
 
 - (instancetype)initWithFolder:(NSURL *)folderURL crypto:(id<SEGCrypto>)crypto
@@ -121,11 +121,16 @@
     [self setJSON:data forKey:key];
 }
 
-+ (NSURL *)applicationSupportDirectoryURL
++ (NSURL *)fileStorageURL
 {
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-    NSString *supportPath = [paths firstObject];
-    return [NSURL fileURLWithPath:supportPath];
+    #if TARGET_OS_TV
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    #else
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+    #endif
+    
+    NSString *storagePath = [paths firstObject];
+    return [NSURL fileURLWithPath:storagePath];
 }
 
 - (NSURL *)urlForKey:(NSString *)key

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.h
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.h
@@ -12,7 +12,7 @@ extern NSString *const SEGSegmentRequestDidFailNotification;
 
 @interface SEGSegmentIntegration : NSObject <SEGIntegration>
 
-- (id)initWithAnalytics:(SEGAnalytics *)analytics httpClient:(SEGHTTPClient *)httpClient storage:(id<SEGStorage>)storage;
+- (id)initWithAnalytics:(SEGAnalytics *)analytics httpClient:(SEGHTTPClient *)httpClient fileStorage:(id<SEGStorage>)fileStorage userDefaultsStorage:(id<SEGStorage>)userDefaultsStorage;
 
 @end
 

--- a/Analytics/Classes/Internal/SEGSegmentIntegration.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegration.m
@@ -95,17 +95,18 @@ static BOOL GetAdTrackingEnabled()
         self.backgroundTaskQueue = seg_dispatch_queue_create_specific("io.segment.analytics.backgroundTask", DISPATCH_QUEUE_SERIAL);
         self.flushTaskID = UIBackgroundTaskInvalid;
 
-#if !TARGET_OS_TV
-        // Check for previous queue/track data in NSUserDefaults and remove if present
         [self dispatchBackground:^{
+            // Check for previous queue data in NSUserDefaults and remove if present.
             if ([[NSUserDefaults standardUserDefaults] objectForKey:SEGQueueKey]) {
                 [[NSUserDefaults standardUserDefaults] removeObjectForKey:SEGQueueKey];
             }
+#if !TARGET_OS_TV
+            // Check for previous track data in NSUserDefaults and remove if present (Traits still exist in NSUserDefaults on tvOS)
             if ([[NSUserDefaults standardUserDefaults] objectForKey:SEGTraitsKey]) {
                 [[NSUserDefaults standardUserDefaults] removeObjectForKey:SEGTraitsKey];
             }
-        }];
 #endif
+        }];
         [self dispatchBackground:^{
             [self trackAttributionData:self.configuration.trackAttributionData];
         }];
@@ -547,10 +548,10 @@ static CTTelephonyNetworkInfo *_telephonyNetworkInfo;
 #if TARGET_OS_TV
         [self.userDefaultsStorage removeKey:SEGUserIdKey];
         [self.userDefaultsStorage removeKey:SEGTraitsKey];
-#endif
+#else
         [self.fileStorage removeKey:kSEGUserIdFilename];
         [self.fileStorage removeKey:kSEGTraitsFilename];
-
+#endif
         self.userId = nil;
         self.traits = [NSMutableDictionary dictionary];
     }];

--- a/Analytics/Classes/Internal/SEGSegmentIntegrationFactory.h
+++ b/Analytics/Classes/Internal/SEGSegmentIntegrationFactory.h
@@ -9,9 +9,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SEGSegmentIntegrationFactory : NSObject <SEGIntegrationFactory>
 
 @property (nonatomic, strong) SEGHTTPClient *client;
-@property (nonatomic, strong) id<SEGStorage> storage;
+@property (nonatomic, strong) id<SEGStorage> userDefaultsStorage;
+@property (nonatomic, strong) id<SEGStorage> fileStorage;
 
-- (instancetype)initWithHTTPClient:(SEGHTTPClient *)client storage:(id<SEGStorage>)storage;
+- (instancetype)initWithHTTPClient:(SEGHTTPClient *)client fileStorage:(id<SEGStorage>)fileStorage userDefaultsStorage:(id<SEGStorage>)userDefaultsStorage;
 
 @end
 

--- a/Analytics/Classes/Internal/SEGSegmentIntegrationFactory.m
+++ b/Analytics/Classes/Internal/SEGSegmentIntegrationFactory.m
@@ -4,18 +4,19 @@
 
 @implementation SEGSegmentIntegrationFactory
 
-- (id)initWithHTTPClient:(SEGHTTPClient *)client storage:(id<SEGStorage>)storage
+- (id)initWithHTTPClient:(SEGHTTPClient *)client fileStorage:(id<SEGStorage>)fileStorage userDefaultsStorage:(id<SEGStorage>)userDefaultsStorage
 {
     if (self = [super init]) {
         _client = client;
-        _storage = storage;
+        _userDefaultsStorage = userDefaultsStorage;
+        _fileStorage = fileStorage;
     }
     return self;
 }
 
 - (id<SEGIntegration>)createWithSettings:(NSDictionary *)settings forAnalytics:(SEGAnalytics *)analytics
 {
-    return [[SEGSegmentIntegration alloc] initWithAnalytics:analytics httpClient:self.client storage:self.storage];
+    return [[SEGSegmentIntegration alloc] initWithAnalytics:analytics httpClient:self.client fileStorage:self.fileStorage userDefaultsStorage:self.userDefaultsStorage];
 }
 
 - (NSString *)key

--- a/AnalyticsTests/FileStorageTest.swift
+++ b/AnalyticsTests/FileStorageTest.swift
@@ -13,7 +13,7 @@ class FileStorageTest : QuickSpec {
   override func spec() {
     var storage : SEGFileStorage!
     beforeEach {
-      let url = SEGFileStorage.fileStorageURL()
+      let url = SEGFileStorage.applicationSupportDirectoryURL()
       expect(url).toNot(beNil())
       expect(url?.lastPathComponent) == "Application Support"
       storage = SEGFileStorage(folder: url!, crypto: nil)
@@ -103,7 +103,7 @@ class FileStorageTest : QuickSpec {
     }
     
     it("should work with crypto") {
-      let url = SEGFileStorage.fileStorageURL()
+      let url = SEGFileStorage.applicationSupportDirectoryURL()
       let crypto = SEGAES256Crypto(password: "thetrees")
       let s = SEGFileStorage(folder: url!, crypto: crypto)
       let dict = [

--- a/AnalyticsTests/FileStorageTest.swift
+++ b/AnalyticsTests/FileStorageTest.swift
@@ -13,7 +13,7 @@ class FileStorageTest : QuickSpec {
   override func spec() {
     var storage : SEGFileStorage!
     beforeEach {
-      let url = SEGFileStorage.applicationSupportDirectoryURL()
+      let url = SEGFileStorage.fileStorageURL()
       expect(url).toNot(beNil())
       expect(url?.lastPathComponent) == "Application Support"
       storage = SEGFileStorage(folder: url!, crypto: nil)
@@ -103,7 +103,7 @@ class FileStorageTest : QuickSpec {
     }
     
     it("should work with crypto") {
-      let url = SEGFileStorage.applicationSupportDirectoryURL()
+      let url = SEGFileStorage.fileStorageURL()
       let crypto = SEGAES256Crypto(password: "thetrees")
       let s = SEGFileStorage(folder: url!, crypto: crypto)
       let dict = [


### PR DESCRIPTION
Changes storage to fileStorage and userDefaultsStorage. Utilizes userDefaults on tvOS for information such as anonymousID and configuration, but moves tvOS's queue into the NSCachesDirectory. The reasoning is that tvOS has a 1mb limit for UserDefaults and the queue can grow rapidly in size, leading to app crashes when saving more than 1mb of data to UserDefaults.